### PR TITLE
Rewrite spell_effects

### DIFF
--- a/creator/Reference/Content/EntityReference/Examples/EntityAttributes/minecraftAttribute_spell_effects.md
+++ b/creator/Reference/Content/EntityReference/Examples/EntityAttributes/minecraftAttribute_spell_effects.md
@@ -7,43 +7,59 @@ ms.prod: gaming
 
 # Entity Documentation - minecraft:spell_effects
 
-`minecraft:spell_effects` allows an entity to define effects to add and remove to the entity when adding this attribute. Unlike components like `addrider`, this component will be reapplied if the player logs out and logs back into the world.
+`minecraft:spell_effects` allows an entity to add or remove status effects from itself.
+
+Similarly to [`addrider`](../EntityComponents/minecraftComponent_addrider.md), this component performs a one-time operation on the entity when added. Removing the component will not change the entity's current effects. Adding different versions of the component multiple times will perform each one in turn. Once the component has been added, it will not provide any further functionality.
+
+There is one exception to this. If this component is present on a player, its effects will be re-applied every time the player enters the world. To avoid this, simply remove the component shortly after adding it, or add an empty component to replace it.
 
 ## Parameters
 
-|Name |Default Value  |Type  |Description  |
-|:----------|:----------|:----------|:----------|
-|add_effects|*not set* | List|  List of effects to add to this entity after adding this component |
-|remove_effects|*not set* | String|  List of identifiers of effects to be removed from this entity after adding this component |
+### `add_effects`
 
-### add_effects
+This is a list of status effect objects. These define which effects should be added to the entity when the component is applied. Each object contains the following properties:
 
-`add_effects` is a list variable that can use the following parameters:
+* `effect`: The string identifier of the status effect to add. These are the same as used in the `/effect` command.
+* `duration`: The amount of time in seconds the effect should last. This allows for fractional numbers. For example, instant effects should be set to 0.05 seconds (one tick).
+* `amplifier`: The level of the effect, same as used in the `/effect` command (0 for level I, 1 for level II, etc).
+* `ambient`: Boolean value that should cause the particles emitted by the entity to be partially transparent. This does not work properly, resulting in this property having no effect.
+* `visible`: Boolean value that determines whether the particles emitted by the entity should appear.
+* `display_on_screen_animation`: Boolean value. When set to true, applying this effect displays an animated graphic on-screen similar to the totem of undying effect. Obviously, this only works for players.
 
-| effect| *not set*| String|  Effect to add to this entity. Includes 'duration' in seconds, 'amplifier' level, 'ambient' if the effect should be partially transparent, and 'visible' if the effect should be visible |
+### `remove_effects`
+This can either be a single string identifier for a status effect, or a list of them. These define which effects should be removed from the entity, if present, when the component is applied.
 
 ## Example
 
 ```json
-"minecraft:spell_effects":{
-    "add_effects":[
-    {
-        "effect": "instant_health",
-        "duration": 25
-    }
+"minecraft:spell_effects": {
+    "add_effects": [
+        {
+            "effect": "regeneration",
+            "duration": 25,
+            "amplifier": 2,
+            "visible": false,
+            "display_on_screen_animation": true
+        },
+        {
+            "effect": "instant_health",
+            "duration": 0.05
+        }
     ],
-    "remove_effects": ["poison", "instant_health"]
+    "remove_effects": ["poison", "wither"]
 }
 ```
 
 ## Vanilla entities examples
 
-### zombie_villager_v2
+### `zombie_villager_v2`
+
+Note that the use of `heal` in this example is incorrect and does nothing, since `instant_health` is the correct name for that effect.
 
 :::code language="json" source="../../../../Source/VanillaBehaviorPack/entities/zombie_villager_v2.json" range="86-98":::
 
 ## Vanilla entities using `minecraft:spell_effects`
 
-- [player](../../../../Source/VanillaBehaviorPack_Snippets/entities/player.md)
-- [zombie_villager_v2](../../../../Source/VanillaBehaviorPack_Snippets/entities/zombie_villager_v2.md)
-- [zombie_villager](../../../../Source/VanillaBehaviorPack_Snippets/entities/zombie_villager.md)
+- [`player`](../../../../Source/VanillaBehaviorPack_Snippets/entities/player.md)
+- [`zombie_villager_v2`](../../../../Source/VanillaBehaviorPack_Snippets/entities/zombie_villager_v2.md)
+- [`zombie_villager`](../../../../Source/VanillaBehaviorPack_Snippets/entities/zombie_villager.md)


### PR DESCRIPTION
Hello, I made some further changes to the `spell_effects` component documentation to fully address the issues mentioned in my comment earlier (https://github.com/MicrosoftDocs/minecraft-creator/issues/108#issuecomment-897943950).

This makes the following changes and clarifications:
* Clarify that players are the sole exception to this component behaving exactly like `addrider`
* Link to `addrider` (I hope this link works properly)
* Explicitly describe what being like `addrider` means (component only does something when added)
* Replace cramped table with irrelevant/inaccurate columns like "default value" and "type" with two sections that describe the two top-level properties of the component, with ample room for describing each effect property
* Add `display_on_screen_animation` property
* Clarify that `duration` accepts fractional numbers
* Clarify that `ambient` does not work
* Clarify that `remove_effects` can be either a string or a list
* Redo the example to be better-indented, use more sensical effects, and showcase more properties
* Clarify that vanilla's use of `heal` is wrong