### PR TITLE
minecraft:spawn_entity documentation correction

### DIFF
--- a/creator/Reference/Content/EntityReference/Examples/EntityComponents/minecraftComponent_spawn_entity.md
+++ b/creator/Reference/Content/EntityReference/Examples/EntityComponents/minecraftComponent_spawn_entity.md
@@ -13,6 +13,12 @@ ms.prod: gaming
 
 |Name |Default Value  |Type  |Description  |
 |:----------|:----------|:----------|:----------|
+| entities | *not set*|List of entities | A list of entities to spawn in |
+
+## Entities
+
+|Name |Default Value  |Type  |Description  |
+|:----------|:----------|:----------|:----------|
 | filters| *not set*| Minecraft Filter| If present, the specified entity will only spawn if the filter evaluates to true. |
 | max_wait_time| 600| Integer| Maximum amount of time to randomly wait in seconds before another entity is spawned. |
 | min_wait_time| 300| Integer| Minimum amount of time to randomly wait in seconds before another entity is spawned. |
@@ -29,19 +35,22 @@ ms.prod: gaming
 
 ```json
 "minecraft:spawn_entity":{
-    "filters": [
-        {"test":"is_daytime", "value": false}
-    ] ,
-    "max_wait_time": 600,
-    "min_wait_time": 300,
-    "num_to_spawn": 1,
-    "should_leash": false,
-    "single_use": false,
-    "spawn_entity": ,
-    "spawn_event": "minecraft:entity_born",
-    "spawn_item": "egg",
-    "spawn_method": "born",
-    "spawn_sound": "plop",
+    "entities": [{
+        "filters": [
+            {"test":"is_daytime", "value": false}
+        ] ,
+        "max_wait_time": 600,
+        "min_wait_time": 300,
+        "num_to_spawn": 1,
+        "should_leash": false,
+        "single_use": false,
+        "spawn_entity": ,
+        "spawn_event": "minecraft:entity_born",
+        "spawn_item": "egg",
+        "spawn_method": "born",
+        "spawn_sound": "plop",
+        }
+    ]
 }
 ```
 


### PR DESCRIPTION
minecraft:spawn_entity has only one accepted property: entities, which can be a list or object with the describe properties already mentioned on page, see the `chicken` and `wandering_trader` for examples

Wandering trader example:
```json
      "minecraft:spawn_entity": {
        "entities": [
          {
            "min_wait_time": 0,
            "max_wait_time": 0,
            "spawn_entity": "llama",
            "spawn_event": "minecraft:from_wandering_trader",
            "single_use": true,
            "num_to_spawn": 2,
            "should_leash": true
          }
        ]
      },
```