### PR TITLE
Add a link from each EventSignal class to the respective Event class.

### DIFF
--- a/creator/ScriptAPI/mojang-minecraft/BeforeChatEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/BeforeChatEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: BeforeChatEvent) => undefined): (arg: BeforeChatEvent)
 
 Adds a callback that will be called before new chat messages are sent.
 #### **Parameters**
-- **callback**: (arg: BeforeChatEvent) => undefined
+- **callback**: (arg: [*BeforeChatEvent*](BeforeChatEvent.md)) => undefined
 
-#### **Returns** (arg: BeforeChatEvent) => undefined
+#### **Returns** (arg: [*BeforeChatEvent*](BeforeChatEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: BeforeChatEvent) => undefined): void
 
 Removes a callback from being called before new chat messages are sent.
 #### **Parameters**
-- **callback**: (arg: BeforeChatEvent) => undefined
+- **callback**: (arg: [*BeforeChatEvent*](BeforeChatEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/BeforeExplosionEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/BeforeExplosionEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: BeforeExplosionEvent) => undefined): (arg: BeforeExplo
 
 Adds a callback that will be called when before an explosion occurs. The callback can optionally change or cancel explosion behavior.
 #### **Parameters**
-- **callback**: (arg: BeforeExplosionEvent) => undefined
+- **callback**: (arg: [*BeforeExplosionEvent*](BeforeExplosionEvent.md)) => undefined
 
-#### **Returns** (arg: BeforeExplosionEvent) => undefined
+#### **Returns** (arg: [*BeforeExplosionEvent*](BeforeExplosionEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: BeforeExplosionEvent) => undefined): void
 
 Removes a callback from being called from before when an explosion would occur.
 #### **Parameters**
-- **callback**: (arg: BeforeExplosionEvent) => undefined
+- **callback**: (arg: [*BeforeExplosionEvent*](BeforeExplosionEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/BeforeItemDefinitionEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/BeforeItemDefinitionEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: BeforeItemDefinitionTriggeredEvent) => undefined): (ar
 
 Adds a callback that will be called when an item's definition and components change.
 #### **Parameters**
-- **callback**: (arg: BeforeItemDefinitionTriggeredEvent) => undefined
+- **callback**: (arg: [*BeforeItemDefinitionTriggeredEvent*](BeforeItemDefinitionTriggeredEvent.md)) => undefined
 
-#### **Returns** (arg: BeforeItemDefinitionTriggeredEvent) => undefined
+#### **Returns** (arg: [*BeforeItemDefinitionTriggeredEvent*](BeforeItemDefinitionTriggeredEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: BeforeItemDefinitionTriggeredEvent) => undefined): v
 
 Removes a callback from being called when an item's definition and components change.
 #### **Parameters**
-- **callback**: (arg: BeforeItemDefinitionTriggeredEvent) => undefined
+- **callback**: (arg: [*BeforeItemDefinitionTriggeredEvent*](BeforeItemDefinitionTriggeredEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/BeforeItemUseEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/BeforeItemUseEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: BeforeItemUseEvent) => undefined): (arg: BeforeItemUse
 
 Adds a callback that will be called before an item is used.
 #### **Parameters**
-- **callback**: (arg: BeforeItemUseEvent) => undefined
+- **callback**: (arg: [*BeforeItemUseEvent*](BeforeItemUseEvent.md)) => undefined
 
-#### **Returns** (arg: BeforeItemUseEvent) => undefined
+#### **Returns** (arg: [*BeforeItemUseEvent*](BeforeItemUseEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: BeforeItemUseEvent) => undefined): void
 
 Removes a callback from being called before an item is used.
 #### **Parameters**
-- **callback**: (arg: BeforeItemUseEvent) => undefined
+- **callback**: (arg: [*BeforeItemUseEvent*](BeforeItemUseEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/BeforeItemUseOnEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/BeforeItemUseOnEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: BeforeItemUseOnEvent) => undefined): (arg: BeforeItemU
 
 Adds a callback that will be called before an item is used on a block.
 #### **Parameters**
-- **callback**: (arg: BeforeItemUseOnEvent) => undefined
+- **callback**: (arg: [*BeforeItemUseOnEvent*](BeforeItemUseOnEvent.md)) => undefined
 
-#### **Returns** (arg: BeforeItemUseOnEvent) => undefined
+#### **Returns** (arg: [*BeforeItemUseOnEvent*](BeforeItemUseOnEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: BeforeItemUseOnEvent) => undefined): void
 
 Removes a callback from being called before an item is used on a block.
 #### **Parameters**
-- **callback**: (arg: BeforeItemUseOnEvent) => undefined
+- **callback**: (arg: [*BeforeItemUseOnEvent*](BeforeItemUseOnEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/BeforePistonActivateEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/BeforePistonActivateEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: BeforePistonActivateEvent) => undefined): (arg: Before
 
 Adds a callback that will be called before a piston expands or retracts.
 #### **Parameters**
-- **callback**: (arg: BeforePistonActivateEvent) => undefined
+- **callback**: (arg: [*BeforePistonActivateEvent*](BeforePistonActivateEvent.md)) => undefined
 
-#### **Returns** (arg: BeforePistonActivateEvent) => undefined
+#### **Returns** (arg: [*BeforePistonActivateEvent*](BeforePistonActivateEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: BeforePistonActivateEvent) => undefined): void
 
 Removes a callback from being called before a piston expands or retracts.
 #### **Parameters**
-- **callback**: (arg: BeforePistonActivateEvent) => undefined
+- **callback**: (arg: [*BeforePistonActivateEvent*](BeforePistonActivateEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/BlockBreakEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/BlockBreakEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: BlockBreakEvent) => undefined): (arg: BlockBreakEvent)
 
 Adds a callback that will be called when a block is broken by a player.
 #### **Parameters**
-- **callback**: (arg: BlockBreakEvent) => undefined
+- **callback**: (arg: [*BlockBreakEvent*](BlockBreakEvent.md)) => undefined
 
-#### **Returns** (arg: BlockBreakEvent) => undefined
+#### **Returns** (arg: [*BlockBreakEvent*](BlockBreakEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: BlockBreakEvent) => undefined): void
 
 Removes a callback from being called when an block is broken.
 #### **Parameters**
-- **callback**: (arg: BlockBreakEvent) => undefined
+- **callback**: (arg: [*BlockBreakEvent*](BlockBreakEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/BlockExplodeEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/BlockExplodeEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: BlockExplodeEvent) => undefined): (arg: BlockExplodeEv
 
 Adds a callback that will be called when an explosion occurs, as it impacts individual blocks.
 #### **Parameters**
-- **callback**: (arg: BlockExplodeEvent) => undefined
+- **callback**: (arg: [*BlockExplodeEvent*](BlockExplodeEvent.md)) => undefined
 
-#### **Returns** (arg: BlockExplodeEvent) => undefined
+#### **Returns** (arg: [*BlockExplodeEvent*](BlockExplodeEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: BlockExplodeEvent) => undefined): void
 
 Removes a callback from being called when an explosion occurs, as it impacts individual blocks.
 #### **Parameters**
-- **callback**: (arg: BlockExplodeEvent) => undefined
+- **callback**: (arg: [*BlockExplodeEvent*](BlockExplodeEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/BlockPlaceEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/BlockPlaceEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: BlockPlaceEvent) => undefined): (arg: BlockPlaceEvent)
 
 Adds a callback that will be called when a block is placed by a player.
 #### **Parameters**
-- **callback**: (arg: BlockPlaceEvent) => undefined
+- **callback**: (arg: [*BlockPlaceEvent*](BlockPlaceEvent.md)) => undefined
 
-#### **Returns** (arg: BlockPlaceEvent) => undefined
+#### **Returns** (arg: [*BlockPlaceEvent*](BlockPlaceEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: BlockPlaceEvent) => undefined): void
 
 Removes a callback from being called when an block is placed.
 #### **Parameters**
-- **callback**: (arg: BlockPlaceEvent) => undefined
+- **callback**: (arg: [*BlockPlaceEvent*](BlockPlaceEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/ChatEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/ChatEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: ChatEvent) => undefined): (arg: ChatEvent) => undefine
 
 Adds a callback that will be called when new chat messages are sent.
 #### **Parameters**
-- **callback**: (arg: ChatEvent) => undefined
+- **callback**: (arg: [*ChatEvent*](ChatEvent.md)) => undefined
 
-#### **Returns** (arg: ChatEvent) => undefined
+#### **Returns** (arg: [*ChatEvent*](ChatEvent.md)) => undefined
 
 
 #### **Examples**
@@ -49,7 +49,7 @@ unsubscribe(callback: (arg: ChatEvent) => undefined): void
 
 Removes a callback from being called when new chat messages are sent.
 #### **Parameters**
-- **callback**: (arg: ChatEvent) => undefined
+- **callback**: (arg: [*ChatEvent*](ChatEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/EffectAddEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/EffectAddEventSignal.md
@@ -24,10 +24,10 @@ subscribe(callback: (arg: EffectAddEvent) => undefined, options?: EntityEventOpt
 
 Adds a callback that will be called when an effect is added to an entity.
 #### **Parameters**
-- **callback**: (arg: EffectAddEvent) => undefined
+- **callback**: (arg: [*EffectAddEvent*](EffectAddEvent.md)) => undefined
 - **options**?: [*EntityEventOptions*](EntityEventOptions.md) = `null`
 
-#### **Returns** (arg: EffectAddEvent) => undefined
+#### **Returns** (arg: [*EffectAddEvent*](EffectAddEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -37,7 +37,7 @@ unsubscribe(callback: (arg: EffectAddEvent) => undefined): void
 
 Removes a callback from being called when an effect is added to an entity.
 #### **Parameters**
-- **callback**: (arg: EffectAddEvent) => undefined
+- **callback**: (arg: [*EffectAddEvent*](EffectAddEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/EntityCreateEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/EntityCreateEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: EntityCreateEvent) => undefined): (arg: EntityCreateEv
 
 Adds a callback that will be called when a new entity is created.
 #### **Parameters**
-- **callback**: (arg: EntityCreateEvent) => undefined
+- **callback**: (arg: [*EntityCreateEvent*](EntityCreateEvent.md)) => undefined
 
-#### **Returns** (arg: EntityCreateEvent) => undefined
+#### **Returns** (arg: [*EntityCreateEvent*](EntityCreateEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: EntityCreateEvent) => undefined): void
 
 Removes a callback from being called when a new entity is created.
 #### **Parameters**
-- **callback**: (arg: EntityCreateEvent) => undefined
+- **callback**: (arg: [*EntityCreateEvent*](EntityCreateEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/ExplosionEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/ExplosionEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: ExplosionEvent) => undefined): (arg: ExplosionEvent) =
 
 Adds a callback that will be called when an explosion occurs.
 #### **Parameters**
-- **callback**: (arg: ExplosionEvent) => undefined
+- **callback**: (arg: [*ExplosionEvent*](ExplosionEvent.md)) => undefined
 
-#### **Returns** (arg: ExplosionEvent) => undefined
+#### **Returns** (arg: [*ExplosionEvent*](ExplosionEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: ExplosionEvent) => undefined): void
 
 Removes a callback from being called when an explosion occurs.
 #### **Parameters**
-- **callback**: (arg: ExplosionEvent) => undefined
+- **callback**: (arg: [*ExplosionEvent*](ExplosionEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/ItemDefinitionEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/ItemDefinitionEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: ItemDefinitionTriggeredEvent) => undefined): (arg: Ite
 
 Adds a callback that will be called when an item's definition and components change.
 #### **Parameters**
-- **callback**: (arg: ItemDefinitionTriggeredEvent) => undefined
+- **callback**: (arg: [*ItemDefinitionTriggeredEvent*](ItemDefinitionTriggeredEvent.md)) => undefined
 
-#### **Returns** (arg: ItemDefinitionTriggeredEvent) => undefined
+#### **Returns** (arg: [*ItemDefinitionTriggeredEvent*](ItemDefinitionTriggeredEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: ItemDefinitionTriggeredEvent) => undefined): void
 
 Removes a callback from being called when an item's definition and components change.
 #### **Parameters**
-- **callback**: (arg: ItemDefinitionTriggeredEvent) => undefined
+- **callback**: (arg: [*ItemDefinitionTriggeredEvent*](ItemDefinitionTriggeredEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/ItemUseEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/ItemUseEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: ItemUseEvent) => undefined): (arg: ItemUseEvent) => un
 
 Adds a callback that will be called when an item is used.
 #### **Parameters**
-- **callback**: (arg: ItemUseEvent) => undefined
+- **callback**: (arg: [*ItemUseEvent*](ItemUseEvent.md)) => undefined
 
-#### **Returns** (arg: ItemUseEvent) => undefined
+#### **Returns** (arg: [*ItemUseEvent*](ItemUseEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: ItemUseEvent) => undefined): void
 
 Removes a callback from being called when an item is used.
 #### **Parameters**
-- **callback**: (arg: ItemUseEvent) => undefined
+- **callback**: (arg: [*ItemUseEvent*](ItemUseEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/ItemUseOnEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/ItemUseOnEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: ItemUseOnEvent) => undefined): (arg: ItemUseOnEvent) =
 
 Adds a callback that will be called when an item is used on a block.
 #### **Parameters**
-- **callback**: (arg: ItemUseOnEvent) => undefined
+- **callback**: (arg: [*ItemUseOnEvent*](ItemUseOnEvent.md)) => undefined
 
-#### **Returns** (arg: ItemUseOnEvent) => undefined
+#### **Returns** (arg: [*ItemUseOnEvent*](ItemUseOnEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: ItemUseOnEvent) => undefined): void
 
 Removes a callback from being called when an item is used on a block.
 #### **Parameters**
-- **callback**: (arg: ItemUseOnEvent) => undefined
+- **callback**: (arg: [*ItemUseOnEvent*](ItemUseOnEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/PistonActivateEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/PistonActivateEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: PistonActivateEvent) => undefined): (arg: PistonActiva
 
 Adds a callback that will be called when a piston expands or retracts.
 #### **Parameters**
-- **callback**: (arg: PistonActivateEvent) => undefined
+- **callback**: (arg: [*PistonActivateEvent*](PistonActivateEvent.md)) => undefined
 
-#### **Returns** (arg: PistonActivateEvent) => undefined
+#### **Returns** (arg: [*PistonActivateEvent*](PistonActivateEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: PistonActivateEvent) => undefined): void
 
 Removes a callback from being called when a piston expands or retracts.
 #### **Parameters**
-- **callback**: (arg: PistonActivateEvent) => undefined
+- **callback**: (arg: [*PistonActivateEvent*](PistonActivateEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/PlayerJoinEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/PlayerJoinEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: PlayerJoinEvent) => undefined): (arg: PlayerJoinEvent)
 
 Adds a callback that will be called when a player joins the world.
 #### **Parameters**
-- **callback**: (arg: PlayerJoinEvent) => undefined
+- **callback**: (arg: [*PlayerJoinEvent*](PlayerJoinEvent.md)) => undefined
 
-#### **Returns** (arg: PlayerJoinEvent) => undefined
+#### **Returns** (arg: [*PlayerJoinEvent*](PlayerJoinEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: PlayerJoinEvent) => undefined): void
 
 Removes a callback from being called when a player joins the world.
 #### **Parameters**
-- **callback**: (arg: PlayerJoinEvent) => undefined
+- **callback**: (arg: [*PlayerJoinEvent*](PlayerJoinEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/PlayerLeaveEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/PlayerLeaveEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: PlayerLeaveEvent) => undefined): (arg: PlayerLeaveEven
 
 Adds a callback that will be called when a player leaves the world.
 #### **Parameters**
-- **callback**: (arg: PlayerLeaveEvent) => undefined
+- **callback**: (arg: [*PlayerLeaveEvent*](PlayerLeaveEvent.md)) => undefined
 
-#### **Returns** (arg: PlayerLeaveEvent) => undefined
+#### **Returns** (arg: [*PlayerLeaveEvent*](PlayerLeaveEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: PlayerLeaveEvent) => undefined): void
 
 Removes a callback from being called when a player leaves the world.
 #### **Parameters**
-- **callback**: (arg: PlayerLeaveEvent) => undefined
+- **callback**: (arg: [*PlayerLeaveEvent*](PlayerLeaveEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/TickEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/TickEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: TickEvent) => undefined): (arg: TickEvent) => undefine
 
 Adds a callback that will be called on every tick.
 #### **Parameters**
-- **callback**: (arg: TickEvent) => undefined
+- **callback**: (arg: [*TickEvent*](TickEvent.md)) => undefined
 
-#### **Returns** (arg: TickEvent) => undefined
+#### **Returns** (arg: [*TickEvent*](TickEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: TickEvent) => undefined): void
 
 Removes a callback from being called every tick.
 #### **Parameters**
-- **callback**: (arg: TickEvent) => undefined
+- **callback**: (arg: [*TickEvent*](TickEvent.md)) => undefined
 
 
 > [!WARNING]

--- a/creator/ScriptAPI/mojang-minecraft/WeatherChangeEventSignal.md
+++ b/creator/ScriptAPI/mojang-minecraft/WeatherChangeEventSignal.md
@@ -24,9 +24,9 @@ subscribe(callback: (arg: WeatherChangeEvent) => undefined): (arg: WeatherChange
 
 Adds a callback that will be called when weather changes.
 #### **Parameters**
-- **callback**: (arg: WeatherChangeEvent) => undefined
+- **callback**: (arg: [*WeatherChangeEvent*](WeatherChangeEvent.md)) => undefined
 
-#### **Returns** (arg: WeatherChangeEvent) => undefined
+#### **Returns** (arg: [*WeatherChangeEvent*](WeatherChangeEvent.md)) => undefined
 
 
 ### **unsubscribe**
@@ -36,7 +36,7 @@ unsubscribe(callback: (arg: WeatherChangeEvent) => undefined): void
 
 Removes a callback from being called when weather changes.
 #### **Parameters**
-- **callback**: (arg: WeatherChangeEvent) => undefined
+- **callback**: (arg: [*WeatherChangeEvent*](WeatherChangeEvent.md)) => undefined
 
 
 > [!WARNING]


### PR DESCRIPTION
Add a link from each EventSignal class to the respective Event class.
This change will make the reference much more convenient.