### PR TITLE
Remove PATCH from 'method' example

### DIFF
--- a/creator/ScriptAPI/mojang-net/HttpRequest.md
+++ b/creator/ScriptAPI/mojang-net/HttpRequest.md
@@ -30,7 +30,7 @@ Type: [*HttpHeader*](HttpHeader.md)[]
 ### **method**
 `method: HttpRequestMethod;`
 
-HTTP method (e.g., GET or PUT or PATCH) to use for making the request.
+HTTP method (e.g., GET or PUT or POST) to use for making the request.
 
 Type: [*HttpRequestMethod*](HttpRequestMethod.md)
 


### PR DESCRIPTION
GameTest doesn't support http request method PATCH, so I replace it with POST because it's a more common http request method & GameTest supports it.