### PR TITLE
Update "bridge." section in CommonlyUsedTools

### DIFF
--- a/creator/Documents/CommonlyUsedTools.md
+++ b/creator/Documents/CommonlyUsedTools.md
@@ -48,7 +48,7 @@ Image Map is a small application for both Bedrock Edition and Java Edition that 
 
 ### [bridge.](https://bridge-core.app)
 
-bridge. is a powerful add-on editor designed to speed up your development process. It provides a rich editing experience for all files inside behavior packs, resource packs, skin packs and world templates and provides a powerful work environment for JavaScript, JSON, functions and more. A summary of bridge.'s most notable features can be found [here](https://bridge-core.app/guide/features/index.html). 
+bridge. is a powerful add-on editor designed to speed up your development process. It provides a rich editing experience for all files inside behavior packs, resource packs, skin packs and world templates and provides a powerful work environment for JavaScript/TypeScript files, JSON files, functions and more. A summary of bridge.'s most notable features can be found [here](https://bridge-core.app/guide/features/index.html). 
 
 Are you wondering why you should use bridge. over other editors? Read [this page](https://bridge-core.app/guide/why-bridge.html) to discover what features are unique to bridge.
 

--- a/creator/Documents/CommonlyUsedTools.md
+++ b/creator/Documents/CommonlyUsedTools.md
@@ -48,9 +48,11 @@ Image Map is a small application for both Bedrock Edition and Java Edition that 
 
 ### [bridge.](https://bridge-core.app)
 
-bridge. is a powerful add-on editor designed to speed up your development process. It provides a rich editing experience for all files inside behavior packs, resource packs, skin packs and world templates and provides a powerful work environment for JavaScript, JSON, functions and more. bridge. also allows you to choose between the tree editor or raw text editor for JSON files. A summary of bridge.'s most notable features can be found [here](https://github.com/bridge-core/editor/blob/main/README.md). Unleash the full power of add-ons with [bridge. extensions](https://bridge-core.app/extension-docs/) and make use of rich auto-completions provided as you navigate through a file.
+bridge. is a powerful add-on editor designed to speed up your development process. It provides a rich editing experience for all files inside behavior packs, resource packs, skin packs and world templates and provides a powerful work environment for JavaScript, JSON, functions and more. A summary of bridge.'s most notable features can be found [here](https://bridge-core.app/guide/features/index.html). 
 
-You can also visit the [github repo](https://github.com/solvedDev/bridge.) by clicking the link provided.
+Are you wondering why you should use bridge. over other editors? Read [this page](https://bridge-core.app/guide/why-bridge.html) to discover what features are unique to bridge.
+
+bridge. is open source and you can visit the [github repo](https://github.com/bridge-core/editor) by clicking the link provided.
 
 ## Server Based Tools
 


### PR DESCRIPTION
With today's release of [bridge. v2.3.0](https://github.com/bridge-core/editor/releases/tag/v2.3.0) we have released rewrites and updates of our documentation; this PR modifies some of the links to bridge. and slightly changes the wording of its description on this page.

