### PR TITLE
Change UUID capital F to to lowercase

### DIFF
--- a/creator/Documents/GameTestBuildYourFirstGameTest.md
+++ b/creator/Documents/GameTestBuildYourFirstGameTest.md
@@ -85,7 +85,7 @@ A behavior pack manifest needs to have additional elements to support GameTests.
             "description": "Script that implements basic starter tests.",
             "type": "script",
             "language": "javascript",
-            "uuid": "1a1b53fc-5653-4a75-91b7-9cdF027674ae",
+            "uuid": "1a1b53fc-5653-4a75-91b7-9cdf027674ae",
             "version": [0, 0, 1],
             "entry": "scripts/StarterTests.js"
         }


### PR DESCRIPTION
VS Code gives a warning when a capital F is provided and the recommended extensions are installed:

Uuid

This is a unique identifier for the module in the same format as the pack's UUID in the header. This should be different from the pack's UUID, and different for every module

String does not match the pattern of "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$".

![image](https://user-images.githubusercontent.com/7833360/190881405-15f63d7e-1bcc-424a-a65d-afc1158955ab.png)
