### PR TITLE
Missed OR operator in the Logical Operators

### DIFF
--- a/creator/Reference/Content/MolangReference/Examples/MolangConcepts/MolangIntroduction.md
+++ b/creator/Reference/Content/MolangReference/Examples/MolangConcepts/MolangIntroduction.md
@@ -48,7 +48,7 @@ All identifiers not in a scope listed below are reserved for future use.
 | Keyword| Description |
 |:-----------|:-----------|
 | `1.23`| Numerical constant value |
-| `! && < <= >= > == !=`| Logical operators |
+| `! || && < <= >= > == !=`| Logical operators |
 | `* / + -`| Basic math operators |
 | `(` `)`| Parentheses for expression term evaluation control |
 | `{` `}`| Braces for execution scope |


### PR DESCRIPTION
This is missing from the list of available operators. It is seen in the documentation given when downloading the sample packs from https://github.com/Mojang/bedrock-samples/