### PR TITLE
fix: cleanup actor_animation_controller

### DIFF
--- a/creator/.openpublishing.redirection.json
+++ b/creator/.openpublishing.redirection.json
@@ -12,7 +12,7 @@
       },
       {
         "source_path": "Reference/Content/SchemasReference/Schemas/minecraftSchema_actor_animation_controller_1.10.0.md",
-        "redirect_url": "/reference/content/schemasreference/schemas/schemaslist.md",
+        "redirect_url": "/reference/content/schemasreference/schemaslist",
         "redirect_document_id": false
       }
     ]

--- a/creator/Reference/Content/SchemasReference/Schemas/TOC.yml
+++ b/creator/Reference/Content/SchemasReference/Schemas/TOC.yml
@@ -2,8 +2,6 @@
    href: ../SchemasList.md
  - name: actor_animation
    href: minecraftSchema_actor_animation_1.8.0.md
- - name: actor_animation_controller
-   href: minecraftSchema_actor_animation_controller_1.10.0.md
  - name: block_reference
    href: minecraftSchema_block_reference_1.10.0.md
  - name: chance_information

--- a/creator/TOC.yml
+++ b/creator/TOC.yml
@@ -310,8 +310,6 @@
             href: Reference/Content/schemasreference/SchemasList.md
           - name: actor_animation
             href: Reference/Content/SchemasReference/Schemas/minecraftSchema_actor_animation_1.8.0.md
-          - name: actor_animation_controller
-            href: Reference/Content/SchemasReference/Schemas/minecraftSchema_actor_animation_controller_1.10.0.md
           - name: block_reference
             href: Reference/Content/SchemasReference/Schemas/minecraftSchema_block_reference_1.10.0.md
           - name: chance_information


### PR DESCRIPTION
## Problem

A link to `actor_animation_controller` was still rendering in navigation, and when clicked was routing to the 404 page.

## Changes

- Update `redirect_url`
- Remove `actor_animation_controller` from TOC sidebar