### PR TITLE
Fixed links to ageable and ambient_sound_interval

### DIFF
--- a/creator/Reference/Content/EntityReference/Examples/EntityComponents/TOC.yml
+++ b/creator/Reference/Content/EntityReference/Examples/EntityComponents/TOC.yml
@@ -5,9 +5,9 @@
 - name: admire_item
   href: minecraftComponent_admire_item.md
 - name: ageable
-  href: minecraftComponent_ambient_sound_interval.md
-- name: ambient_sound_interval
   href: minecraftComponent_ageable.md
+- name: ambient_sound_interval
+  href: minecraftComponent_ambient_sound_interval.md
 - name: anger_level
   href: minecraftComponent_anger_level.md
 - name: angry


### PR DESCRIPTION
The ageable link was directing to the documentation page for ambient_sound_interval and vice versa. This just swaps them.