### PR TITLE
Correct is_variant example values' types

### DIFF
--- a/creator/Reference/Content/EntityReference/Examples/Filters/is_variant.md
+++ b/creator/Reference/Content/EntityReference/Examples/Filters/is_variant.md
@@ -50,13 +50,13 @@ Returns true if the subject entity is the variant number provided.
 ### Full
 
 ```json
-{ "test": "is_variant", "subject": "self", "operator": "equals", "value": "0" }
+{ "test": "is_variant", "subject": "self", "operator": "equals", "value": 0 }
 ```
 
 ### Short (using Defaults)
 
 ```json
-{ "test": "is_variant", "value": "0" }
+{ "test": "is_variant", "value": 0 }
 ```
 
 ## Vanilla entities examples


### PR DESCRIPTION
The "value" property of is_variant requires an integer. Both examples currently use a string containing a number, which will not work when used in-game and throws errors.