### PR TITLE
Corrected sittable component example code

### DIFF
--- a/creator/Reference/Content/EntityReference/Examples/EntityComponents/minecraftComponent_sittable.md
+++ b/creator/Reference/Content/EntityReference/Examples/EntityComponents/minecraftComponent_sittable.md
@@ -21,8 +21,8 @@ description: "A reference document detailing the 'sittable' entity component"
 
 ```json
 "minecraft:sittable":{
-    "sit_event": "minecraft:taking_a_seat",
-    "stand_event": "minecraft:time_to_go"
+    "sit_event": {"event": "minecraft:taking_a_seat"},
+    "stand_event": {"event": "minecraft:time_to_go"}
 }
 ```
 


### PR DESCRIPTION
"sit_event" and "stand_event" require object values, not string values. Current code sample will throw errors, new code sample will work as intended.