### PR TITLE
Added default value and type to parameter in minecraft_max_stack_size.md

### DIFF
--- a/creator/Reference/Content/ItemReference/Examples/ItemComponents/minecraft_max_stack_size.md
+++ b/creator/Reference/Content/ItemReference/Examples/ItemComponents/minecraft_max_stack_size.md
@@ -14,4 +14,4 @@ ms.service: minecraft-bedrock-edition
 
 |Name |Default Value  |Type  |Description  |
 |:----------|:----------|:----------|:----------|
-| value|*not set*| | How many of an item that can be stacked together.|
+| value|64|Integer | How many of an item that can be stacked together.|


### PR DESCRIPTION
The default stack size of a new item is 64, and the type for the parameter "value" is Integer.