### PR TITLE
Correct parameter type in minecraft_projectile.md

### DIFF
--- a/creator/Reference/Content/ItemReference/Examples/ItemComponents/minecraft_projectile.md
+++ b/creator/Reference/Content/ItemReference/Examples/ItemComponents/minecraft_projectile.md
@@ -15,7 +15,7 @@ ms.service: minecraft-bedrock-edition
 |Name |Default Value  |Type  |Description  |
 |:----------|:----------|:----------|:----------|
 |minimum_critical_power|*not set*| Float| Defines the time a projectile needs to charge in order to critically hit|
-|projectile_entity|*not set* | JSON object| The entity to be fired as a projectile|
+|projectile_entity|*not set* | String| The entity to be fired as a projectile. If no namespace is specified, it is assumed to be `minecraft`|
 
 See [Custom Item Use Priority](../ItemUsePriority.md) for more information on dispense behavior.
 


### PR DESCRIPTION
projectile_entity takes a String value equivalent to the identifier of the desired entity, not a JSON object.