### PR TITLE
Remove inapplicable vanilla examples from is_raider.md

### DIFF
--- a/creator/Reference/Content/EntityReference/Examples/Filters/is_raider.md
+++ b/creator/Reference/Content/EntityReference/Examples/Filters/is_raider.md
@@ -56,16 +56,3 @@ Tests if the subject is a raider.
 ```json
 { "test": "is_raider" }
 ```
-
-## Vanilla entities examples
-
-### zoglin
-
-```json
-{ "test": "is_persistent", "value": false }
-```
-
-## Vanilla entities using `is_persistent`
-
-- [piglin_brute](../../../../Source/VanillaBehaviorPack_Snippets/entities/piglin_brute.md)
-- [zoglin](../../../../Source/VanillaBehaviorPack_Snippets/entities/zoglin.md)


### PR DESCRIPTION
There are currently vanilla examples of is_persistent at the bottom of this page, these should be removed as that's the wrong filter. There are no vanilla entities that use is_raider.