### PR TITLE
Add other vanilla entities using block_climber

### DIFF
--- a/creator/Reference/Content/EntityReference/Examples/EntityComponents/minecraftComponent_block_climber.md
+++ b/creator/Reference/Content/EntityReference/Examples/EntityComponents/minecraftComponent_block_climber.md
@@ -8,7 +8,7 @@ ms.service: minecraft-bedrock-edition
 
 # Entity Documentation - minecraft:block_climber
 
-`minecraft:block_climber` allows the player to detect and manuever on the scaffolding block.
+`minecraft:block_climber` allows an entity to detect and manuever on the scaffolding block.
 
 ## Example
 
@@ -18,10 +18,15 @@ ms.service: minecraft-bedrock-edition
 
 ## Vanilla entities examples
 
+### player
 ```json
 "minecraft:block_climber": {}
 ```
 
 ## Vanilla entities using `minecraft:block_climber`
 
+- [endermite](../../../../Source/VanillaBehaviorPack_Snippets/entities/endermite.md)
+- [fox](../../../../Source/VanillaBehaviorPack_Snippets/entities/fox.md)
 - [player](../../../../Source/VanillaBehaviorPack_Snippets/entities/player.md)
+- [rabbit](../../../../Source/VanillaBehaviorPack_Snippets/entities/rabbit.md)
+- [silverfish](../../../../Source/VanillaBehaviorPack_Snippets/entities/silverfish.md)


### PR DESCRIPTION
The player is not the only vanilla entity that uses the block_climber component, so page should be updated to reflect the other entities that do.