### PR TITLE
Corrected vanilla entities in minecraftTrigger_on_friendly_anger.md

### DIFF
--- a/creator/Reference/Content/EntityReference/Examples/EntityTriggers/minecraftTrigger_on_friendly_anger.md
+++ b/creator/Reference/Content/EntityReference/Examples/EntityTriggers/minecraftTrigger_on_friendly_anger.md
@@ -41,6 +41,6 @@ ms.service: minecraft-bedrock-edition
 
 ## Vanilla entities using `minecraft:on_friendly_anger`
 
-- [llama](../../../../Source/VanillaBehaviorPack_Snippets/entities/llama.md)
 - [panda](../../../../Source/VanillaBehaviorPack_Snippets/entities/panda.md)
 - [polar_bear](../../../../Source/VanillaBehaviorPack_Snippets/entities/polar_bear.md)
+- [trader_llama](../../../../Source/VanillaBehaviorPack_Snippets/entities/trader_llama.md)


### PR DESCRIPTION
The llama does not have this component, but the trader llama does. Replaced the link to llama with the link to trader llama.