### PR TITLE
Split example in minecraftComponent_spawn_entity.md

### DIFF
--- a/creator/Reference/Content/EntityReference/Examples/EntityComponents/minecraftComponent_spawn_entity.md
+++ b/creator/Reference/Content/EntityReference/Examples/EntityComponents/minecraftComponent_spawn_entity.md
@@ -35,6 +35,7 @@ ms.service: minecraft-bedrock-edition
 
 ## Example
 
+### Spawning an entity
 ```json
 "minecraft:spawn_entity":{
     "entities": [{
@@ -46,10 +47,29 @@ ms.service: minecraft-bedrock-edition
         "num_to_spawn": 1,
         "should_leash": false,
         "single_use": false,
-        "spawn_entity": ,
+        "spawn_entity": "minecraft:chicken",
         "spawn_event": "minecraft:entity_born",
-        "spawn_item": "egg",
         "spawn_method": "born",
+        "spawn_sound": "plop",
+        }
+    ]
+}
+```
+
+### Spawning an item
+```json
+"minecraft:spawn_entity":{
+    "entities": [{
+        "filters": [
+            {"test":"is_daytime", "value": false}
+        ] ,
+        "max_wait_time": 600,
+        "min_wait_time": 300,
+        "num_to_spawn": 1,
+        "should_leash": false,
+        "single_use": false,
+        "spawn_item_event": { "event": "example:just_laid_an_egg" },
+        "spawn_item": "egg",
         "spawn_sound": "plop",
         }
     ]


### PR DESCRIPTION
Because this component can spawn an item or an entity, and its properties differ in each case, the example should be split into two distinct examples. The current example does not show the proper use of "spawn_item_event" despite spawning an item, and shows "spawn_entity" despite not actually spawning an entity. It's very counterintuitive.

This commit makes one example that shows how one would spawn a baby chicken, and a separate example that shows how one would spawn an egg.