### PR TITLE
Fix System.run() documentation in minecraft server System.md

### DIFF
--- a/creator/ScriptAPI/minecraft/server/System.md
+++ b/creator/ScriptAPI/minecraft/server/System.md
@@ -80,12 +80,10 @@ Runs a specified function at a future time. This is frequently used to implement
       if (mc.system.currentTick % 1200 === 0) {
         mc.world.sendMessage("Another minute passes...");
       }
-      else {
-        mc.system.run(trapTick);
-      }
     } catch (e) {
       console.warn("Error: " + e);
     }
+    mc.system.run(trapTick);
   }
   mc.system.run(trapTick);
 ```


### PR DESCRIPTION
- run() method description is wrong (describes runTimeout)
- example will not display message in every minute as the script suggests, unless we wrap it in a function and re-run every tick