### PR TITLE
Remove inaccurate note from minecraftBehavior_sneeze.md

### DIFF
--- a/creator/Reference/Content/EntityReference/Examples/EntityGoals/minecraftBehavior_sneeze.md
+++ b/creator/Reference/Content/EntityReference/Examples/EntityGoals/minecraftBehavior_sneeze.md
@@ -10,9 +10,6 @@ ms.service: minecraft-bedrock-edition
 
 `minecraft:behavior.sneeze` compels an entity to sneeze and potentially startle other entities. While sneezing, the entity may drop an item.
 
-> [!NOTE]
-> `minecraft:behavior.sneeze` requires a `player` to be tagged as the entity's owner, via taming or console command.
-
 ## Parameters
 
 |Name |Default Value  |Type  |Description  |


### PR DESCRIPTION
minecraft:behavior.sneeze does not require the entity to have an owner; this note saying it does seems to have been a mis-copy/paste.