### PR TITLE
Remove invalid preceding slash in queue_command example

### DIFF
--- a/creator/Reference/Content/EntityReference/Examples/EntityEvents/minecraftEvents_queue_command.md
+++ b/creator/Reference/Content/EntityReference/Examples/EntityEvents/minecraftEvents_queue_command.md
@@ -28,7 +28,7 @@ Note that commands executed via `queue_command` are guaranteed to run in order w
 
 ```json
 "queue_command":{
-    "command" : "/give @p emerald",
+    "command" : "give @p emerald",
     "command array": [], //not used
     "target" : "self"
 }


### PR DESCRIPTION
queue_command errors with a preceding slash:

```
[Json][error]-<pack name> | actor_definitions | <path> | <entity id> | minecraft:entity | events | <event name> | queue_command | command | Do not use a forward slash for command entries.
```

