### PR TITLE
corrected wrong titles of 2 links in index.yml

### DIFF
--- a/creator/index.yml
+++ b/creator/index.yml
@@ -96,10 +96,10 @@ conceptualContent:
               text: Popular Commands
             - url: Documents/CommandBlocks.md
               itemType: get-started
-              text: Create an In-World Game with Commands
+              text: Introduction to Command Blocks
             - url: Documents/CreateAnInWorldGame.md
-              itemType: get-started
-              text: How To Make a Complete the Monument World
+              itemType: how-to-guide
+              text: Create an In-World Game with Commands
             - url: Commands/index.yml
               itemType: reference
               text: Command Reference Documentation


### PR DESCRIPTION
For one of the links I set the title "_Introduction to Command Blocks_" to make it have a more general meaning on the index page,
however - if it's required to be exact as the page caption - the title may be changed to "_Getting Started with Command Blocks_".

Next, could anyone check if there exists a separate guide "_How To Make a Complete the Monument World_" ?
Or it is just the existing "_Create an In-World Game with Commands_" guide ?
It looks like that, as the existing guide mentions a "monument" and its completion.
