### PR TITLE
Add `spawns_underground` rule to spawn components table

### DIFF
--- a/creator/Reference/Content/EntityReference/Examples/ClientEntityDocumentation/DataDrivenSpawning.md
+++ b/creator/Reference/Content/EntityReference/Examples/ClientEntityDocumentation/DataDrivenSpawning.md
@@ -48,8 +48,8 @@ The following components provide the specifics in determining the ways in which 
 | [minecraft:spawns_on_block_filter](../Definitions/NestedTables/spawns_on_block_filter.md) |Allows an entity to spawn on a particular block. |
 | [minecraft:spawns_on_block_prevented_filter](../Definitions/NestedTables/spawns_on_block_prevented_filter.md) |Prevents an entity from spawning on a particular block. |
 | [minecraft:spawns_on_surface](../Definitions/NestedTables/spawns_on_surface.md) |Allows an entity to spawn on the surface. |
-| [minecraft:spawns_underwater](../Definitions/NestedTables/spawns_underwater.md)|Allows the mob to spawn underwater.  |
 | [minecraft:spawns_underground](../Definitions/NestedTables/spawns_underground.md)|Allows an entity to spawn underground.  |
+| [minecraft:spawns_underwater](../Definitions/NestedTables/spawns_underwater.md)|Allows the mob to spawn underwater.  |
 | [minecraft:weight](../Definitions/NestedTables/weight.md)|Allows players to set a priority for how often that mob should spawn. |
 | [minecraft:world_age_filter](../Definitions/NestedTables/world_age_filter.md) |Allows players to set mob spawns after a specified amount of time has passed within a world.|
 

--- a/creator/Reference/Content/EntityReference/Examples/ClientEntityDocumentation/DataDrivenSpawning.md
+++ b/creator/Reference/Content/EntityReference/Examples/ClientEntityDocumentation/DataDrivenSpawning.md
@@ -49,6 +49,7 @@ The following components provide the specifics in determining the ways in which 
 | [minecraft:spawns_on_block_prevented_filter](../Definitions/NestedTables/spawns_on_block_prevented_filter.md) |Prevents an entity from spawning on a particular block. |
 | [minecraft:spawns_on_surface](../Definitions/NestedTables/spawns_on_surface.md) |Allows an entity to spawn on the surface. |
 | [minecraft:spawns_underwater](../Definitions/NestedTables/spawns_underwater.md)|Allows the mob to spawn underwater.  |
+| [minecraft:spawns_underground](../Definitions/NestedTables/spawns_underground.md)|Allows an entity to spawn underground.  |
 | [minecraft:weight](../Definitions/NestedTables/weight.md)|Allows players to set a priority for how often that mob should spawn. |
 | [minecraft:world_age_filter](../Definitions/NestedTables/world_age_filter.md) |Allows players to set mob spawns after a specified amount of time has passed within a world.|
 


### PR DESCRIPTION
I noticed that the `spawns_underground` rule was missing from the spawning components table, this PR adds it.