### PR TITLE
Add `distance_filter` rule to spawn components table

### DIFF
--- a/creator/Reference/Content/EntityReference/Examples/ClientEntityDocumentation/DataDrivenSpawning.md
+++ b/creator/Reference/Content/EntityReference/Examples/ClientEntityDocumentation/DataDrivenSpawning.md
@@ -36,6 +36,7 @@ The following components provide the specifics in determining the ways in which 
 | [minecraft:density_limit](../Definitions/NestedTables/density_limit.md)| Allows players to specify the amount of mobs to spawn in certain locations. |
 | [minecraft:difficulty_filter](../Definitions/NestedTables/difficulty_filter.md)| Allows creators to set which mobs spawn depending on difficulty level. |
 | [minecraft:disallow_spawns_in_bubble](../Definitions/NestedTables/disallow_spawns_in_bubble.md)| Allows creators to keep entities from spawning in bubbles. |
+| [minecraft:distance_filter](../Definitions/NestedTables/distance_filter.md)| Allows players to set specific distances for entities to spawn. |
 | [minecraft:entity_types](../Definitions/NestedTables/entity_types.md) |This is a specific type of JSON object used by Minecraft: Bedrock Edition to encapsulate entity data that can be used in certain behaviors and components. |
 | [minecraft:height_filter](../Definitions/NestedTables/height_filter.md) |Allows players to set mob spawning within specific heights of the map. |
 | [minecraft:herd](../Definitions/NestedTables/herd.md)| Allows players to determine the herd size of animals.|


### PR DESCRIPTION
I noticed the `distance_filter` rule was missing from the spawn components table. This PR is to add it.