### PR TITLE
Update minecraftRecipe_Shapeless.md

### DIFF
--- a/creator/Reference/Content/RecipeReference/Examples/RecipeDefinitions/minecraftRecipe_Shapeless.md
+++ b/creator/Reference/Content/RecipeReference/Examples/RecipeDefinitions/minecraftRecipe_Shapeless.md
@@ -20,7 +20,7 @@ Represents a shapeless crafting recipe.
 |ingredients| Array of item names|  Items used as input (without a shape) for the recipe. |
 |priority| Integer| Sets the priority order of the recipe. Lower numbers represent a higher priority.|
 |result| Array of item names| These items are the result. |
-|tags|String array |(*optional*) Item that can create the shapeless recipe such as "stonecutter". |
+|tags|String array | Item that can create the shapeless recipe such as "stonecutter". |
 
 ## Shapeless Recipe Example
 


### PR DESCRIPTION
Now when not using tags, an error is thrown on BDS. So I'm guessing this is not an optional parameter anymore as of 1.20.80.