### PR TITLE
Add `slot` Enum Documentation & Example to `minecraft_enchantable.md`

### DIFF
--- a/creator/Reference/Content/ItemReference/Examples/ItemComponents/minecraft_enchantable.md
+++ b/creator/Reference/Content/ItemReference/Examples/ItemComponents/minecraft_enchantable.md
@@ -16,3 +16,23 @@ ms.service: minecraft-bedrock-edition
 |:----------|:----------|:----------|:----------|
 |slot|*not set* | String| What enchantments can be applied (ex. Using `bow` would allow this item to be enchanted as if it were a bow).|
 |value |*not set* |--| The value of the enchantment (minimum of 0).|
+
+### slot
+
+Here are the following enchantment slots that can be set for the value of `slot`.
+
+- sword
+- bow
+- armor_head
+- armor_torso
+- armor_legs
+- armor_feet
+
+- ## Example
+
+```json
+"minecraft:enchantable": {
+  "value": 10,
+  "slot": "armor_torso"
+}
+```


### PR DESCRIPTION
I know there is more options for slot, but I don't know what they are.