### PR TITLE
Fix NPM Invocation

### DIFF
--- a/creator/Documents/MCToolsOverview.md
+++ b/creator/Documents/MCToolsOverview.md
@@ -27,7 +27,7 @@ Once you've started your project, you'll see an editor that shows top-level file
 
 Command line tools let you access the power of creator tools from a command line. You can also integrate this into broader processes or project-level tasks.
 
-Command line tools are available via the [@minecraft/creator-tools](https://aka.ms/mctnpm) page on NPM. To install via NPM, install [nodejs tools](https://nodejs.org/) and then run `npm -i @minecraft/creator-tools` from a command line. See the [NPM page](https://aka.ms/mctnpm) for more documentation and sample command lines.
+Command line tools are available via the [@minecraft/creator-tools](https://aka.ms/mctnpm) page on NPM. To install via NPM, install [nodejs tools](https://nodejs.org/) and then run `npm i @minecraft/creator-tools` from a command line. See the [NPM page](https://aka.ms/mctnpm) for more documentation and sample command lines.
 
 
 ## Minecraft Creator Tools - what it does


### PR DESCRIPTION
Changed "npm -i" -> "npm i", as the former will result in an error.

This pull request includes a small change to the `creator/Documents/MCToolsOverview.md` file. The change corrects the npm install command for the `@minecraft/creator-tools` package.

* [`creator/Documents/MCToolsOverview.md`](diffhunk://#diff-86df86284ea4086ce8bdd08b457df931643443e1659462e93bc71fd96ad7770eL30-R30): Corrected the npm install command from `npm -i @minecraft/creator-tools` to `npm i @minecraft/creator-tools`.