### PR TITLE
Corrected molang check for dyed armor

### DIFF
--- a/creator/Documents/AddCustomItems.md
+++ b/creator/Documents/AddCustomItems.md
@@ -904,7 +904,7 @@ You edit **Pack/attachables/custom_chestplate.attachable.json** like this...
 ```json
 "scripts": {
   "pre_animation": [
-    "variable.is_dyed = query.armor_color_slot(1, 0) != 0.0 || query.armor_color_slot(1, 1) != 0.0 || query.armor_color_slot(1, 2) != 0.0 || query.armor_color_slot(1, 3) != 0.0;"
+    "variable.is_dyed = query.armor_color_slot(1, 0) != 1.0 || query.armor_color_slot(1, 1) != 1.0 || query.armor_color_slot(1, 2) != 1.0"
   ]
 }
 ```
@@ -931,7 +931,7 @@ So that the final version of **custom_chestplate.attachable.json** looks like th
       },
       "scripts": {
         "pre_animation": [
-          "variable.is_dyed = query.armor_color_slot(1, 0) != 0.0 || query.armor_color_slot(1, 1) != 0.0 || query.armor_color_slot(1, 2) != 0.0 || query.armor_color_slot(1, 3) != 0.0;"
+          "variable.is_dyed = query.armor_color_slot(1, 0) != 1.0 || query.armor_color_slot(1, 1) != 1.0 || query.armor_color_slot(1, 2) != 1.0"
         ]
       }
     }


### PR DESCRIPTION
For the variable.is_dyed creation I have removed the un-needed check for the alpha channel, and corrected the query.armor_color_slot to check for != 1.0, not 0.0 as 1.0 is the default