### PR TITLE
Updated the Jigsaw Structures Tutorial

### DIFF
--- a/creator/Documents/Structures/IntroductionToJigsawStructures.md
+++ b/creator/Documents/Structures/IntroductionToJigsawStructures.md
@@ -47,7 +47,7 @@ These files are stored within the **worldgen** folder of the behavior pack in th
 behavior_packs 
   <pack_name> 
     worldgen 
-      jigsaw_structures 
+      structures 
         mystructure.json 
       processors 
         mystructureprocessor.json 

--- a/creator/Documents/Structures/JigsawTutorial.md
+++ b/creator/Documents/Structures/JigsawTutorial.md
@@ -13,6 +13,9 @@ In this tutorial, we're going to learn about how to create smaller structures an
 
 ## Demonstration: Working with Jigsaw Structures
 
+> [!WARNING]
+> The video tutorial is using an outdated folder structure. Jigsaw structures are now stored in the **worldgen/structures** folder instead of **worldgen/jigsaw_structures**.
+
 > [!VIDEO https://www.youtube.com/embed/57sLxXDkaA0]
 
 This video shows a way use jigsaw structures, and we are using it as a guide to help us learn the process.
@@ -86,7 +89,7 @@ development_behavior_packs
         <room_structure>.mcstructure
         <hallway_structure>.mcstructure
     worldgen 
-      jigsaw_structures
+      structures
         mystructure.json
       processors
         mystructureprocessor.json
@@ -98,7 +101,7 @@ development_behavior_packs
 
 Here are the contents for each file:
 
-### jigsaw_structures/mystructure.json
+### structures/mystructure.json
 
 [Reference: Worldgen Jigsaw Structures](../../Reference/Content/WorldgenReference/Examples/JigsawJigsawStructures.md)
 


### PR DESCRIPTION
From [Minecraft 1.21.100 changelog](https://feedback.minecraft.net/hc/en-us/articles/38581287884557-Minecraft-1-21-100-Bedrock):

> Changed structure definitions folder from `worldgen/jigsaw_structures` to `worldgen/structures`.

This PR updates the Jigsaw Structures tutorials to match the new folder structure.