### PR TITLE
Update processor_type to protected_blocks in Jigsaws reference documentation

### DIFF
--- a/creator/Reference/Content/WorldgenReference/Examples/JigsawProcessors.md
+++ b/creator/Reference/Content/WorldgenReference/Examples/JigsawProcessors.md
@@ -51,7 +51,7 @@ A list of processors of [processor_type](#processor_type) that will be run when 
     "blocks": ["<block_name>", ...]
   },
   { 
-    "processor_type": "minecraft:block_ignore", 
+    "processor_type": "minecraft:protected_blocks", 
     "value": "<block_tag>"
   },
   { 
@@ -111,7 +111,7 @@ Specifies which blocks in the world cannot be overridden by this structure.
 ```json
 "processors": [ 
   { 
-    "processor_type": "minecraft:block_ignore", 
+    "processor_type": "minecraft:protected_blocks", 
     "value": "<block_tag>"
   },
 ]


### PR DESCRIPTION
This fixes the reference in the protected_blocks example that was referring to the other block_ignore processor