### PR TITLE
Updated item_display_transforms documentation - experimental toggle isn't needed since 1.21.30

### DIFF
--- a/creator/Reference/Content/BlockReference/Examples/ItemDisplayTransforms.md
+++ b/creator/Reference/Content/BlockReference/Examples/ItemDisplayTransforms.md
@@ -11,7 +11,7 @@ ms.service: minecraft-bedrock-edition
 For custom blocks that do not use a basic 1x1x1 cube geometry or have multiple rotation states, the item representation of the block can look a bit odd with the standard block item orientation. To change how a custom block looks in any of the scenarios where the block is rendered as an item, the `"item_display_transforms"` field in the geometry can be used to configure a custom orientation to properly display the block geometry.
 
 > [!Note]
-> You must use geometry version `1.21.0` or greater and the `Upcoming Creator Features` toggle to use `"item_display_transforms"`.
+> You must use geometry version `1.21.0` or greater to use `"item_display_transforms"` or `1.21.110` to use the `"embedded"` item scenario.
 
 ## What are ItemDisplayTransforms
 
@@ -24,6 +24,7 @@ For custom blocks that do not use a basic 1x1x1 cube geometry or have multiple r
 - Item Frame - `"fixed"`
 - Floating Item Entity - `"ground"`
 - Inventory/Gui - `"gui"`
+- Embedded, used for blocks in flower pots with `"minecraft:flower_pottable"` component - `"embedded"`
 
 **Example**
 
@@ -111,9 +112,6 @@ The valid ranges for all parameters are:
 The "Display" tab in the Blockbench model editor will help you to figure out what your block model looks like with custom `"item_display_transforms"`. 
 
 ![Image of a player holding an umbrella in the Blockbench application](../../../Media/ItemDisplayTransforms/blockbench.png)
-
-> [!NOTE]
-> This feature is currently in development for Bedrock edition models. If you convert your model to a Java model, you should be able to use the values from the "Display" tab for your Bedrock model `"item_display_transforms"`. 
 
 ## Example - The Umbrella Block
 


### PR DESCRIPTION
* Experimental toggle is not needed since 1.21.30
https://feedback.minecraft.net/hc/en-us/articles/30220110283533-Minecraft-1-21-30-Bedrock#:~:text=The%20%22item_display_transforms%22%20field%20in%20block%20geometries%20no%20longer%20requires%20the%20%22Upcoming%20Creator%20Features%22%20toggle

* Blockbench supports the display menu with bedrock blocks 

* + added info on embedded item scenario.