### PR TITLE
Update com.mojang folder location in resource pack introduction

### DIFF
--- a/creator/Documents/ResourcePack.md
+++ b/creator/Documents/ResourcePack.md
@@ -43,10 +43,9 @@ We will start by creating a folder called **My_RESOURCE_Pack**. Technically you 
 
 1. Open the **com.mojang** folder.
 
-* Press **Win+R** to open **Run**.
-* If you are using main Minecraft releases, copy and paste the following into the **Open** field: `%localappdata%\Packages\Microsoft.MinecraftUWP_8wekyb3d8bbwe\LocalState\games\com.mojang`
-* Alternatively, if you are using preview Minecraft versions, see more information about the folder to use in [this article](./GDKPCProjectFolder.md)
-* Click **OK**.
+    * Press **Win+R** to open **Run**.
+    * If you are using main Minecraft releases, copy and paste the following into the **Open** field: `%appdata%\Minecraft Bedrock\users\shared\games\com.mojang`
+    * Click **OK**.
 
 2. Double-click the **development_resource_packs** folder to open it.
 3. Add a new folder and name it **My_RESOURCE_Pack**.


### PR DESCRIPTION
Following this documentation on the main Minecraft release (v 1.21.131 as of this PR) results in the resource pack being unavailable.

Per the list item that I've removed, versions 1.21.120+ changed the location of the folder.

This updates the path, removes the link to the migration doc, and indents the child items.

(Fully expecting comments on this. :) )