### PR TITLE
Fix detection rule properties

### DIFF
--- a/creator/Reference/Content/BlockReference/Examples/BlockComponents/minecraftBlock_liquid_detection.md
+++ b/creator/Reference/Content/BlockReference/Examples/BlockComponents/minecraftBlock_liquid_detection.md
@@ -19,14 +19,9 @@ Experimental toggles required: Upcoming Creator Features (in format versions bef
 
 ## Liquid Detection Properties
 
-|Name       |Default Value |Type |Description |Example Values |
-|:----------|:-------------|:----|:-----------|:------------- |
-| can_contain_liquid | false | Boolean true/false | Whether this block can contain the liquid. For example, if the liquid type is `water`, this means the block can be waterlogged. |  | 
-| detection_rules | *not set* | Array of [Detection Rules](#detection-rules) items |  | Block Fabricator: `[{"liquid_type":"water","on_liquid_touches":"broken"}]` | 
-| liquid_type | water | String | The type of liquid this detection rule is for. Currently, `water` is the only supported liquid type. If this field is omitted, `water` will be the liquid type by default. |  | 
-| on_liquid_touches | blocking | [Minecraft Event Trigger](../Definitions/NestedTables/triggers.md) | How the block reacts to flowing water. Must be one of the following options:<br>"blocking" - The default value for this field. The block stops the liquid from flowing.<br>"broken" - The block is destroyed completely.<br>"popped" - The block is destroyed and its item is spawned.<br>"no_reaction" - The block is unaffected; visually, the liquid will flow through the block. |  | 
-| stops_liquid_flowing_from_direction | *not set* | Array of strings | When a block contains a liquid, controls the directions in which the liquid can't flow out from the block. Also controls the directions in which a block can stop liquid flowing into it if `no_reaction` is set for the `on_liquid_touches` field. Can be a list of the following directions: "up", "down", "north", "south", "east", "west". The default is an empty list; this means that liquid can flow out of all directions by default. |  | 
-| use_liquid_clipping | false | Boolean true/false | Whether this block uses the encompassing collider to visually clip the liquid. The encompassing collider is the smallest single AABB that contains all of the block's colliders. |  | 
+|Name       |Default Value |Type  |Example Values |
+|:----------|:-------------|:----|:------------- |
+| detection_rules | *not set* | Array of [Detection Rules](#detection-rules) items | Block Fabricator: `[{"liquid_type":"water","on_liquid_touches":"broken"}]` | 
 
 ## Detection Rules
 
@@ -34,8 +29,11 @@ Experimental toggles required: Upcoming Creator Features (in format versions bef
 
 |Name       |Default Value |Type |Description |Example Values |
 |:----------|:-------------|:----|:-----------|:------------- |
-| liquid_type | *not set* | String |  | Block Fabricator: `"water"` | 
-| on_liquid_touches | *not set* | String |  | Block Fabricator: `"broken"` | 
+| can_contain_liquid | false | Boolean true/false | Whether this block can contain the liquid. For example, if the liquid type is `water`, this means the block can be waterlogged. |  | 
+| liquid_type | *not set* | String | The type of liquid this detection rule is for. Currently, `water` is the only supported liquid type. If this field is omitted, `water` will be the liquid type by default. | Block Fabricator: `"water"` | 
+| on_liquid_touches | *not set* | String | How the block reacts to flowing water. Must be one of the following options:<br>"blocking" - The default value for this field. The block stops the liquid from flowing.<br>"broken" - The block is destroyed completely.<br>"popped" - The block is destroyed and its item is spawned.<br>"no_reaction" - The block is unaffected; visually, the liquid will flow through the block. | Block Fabricator: `"broken"` | 
+| stops_liquid_flowing_from_direction | *not set* | Array of strings | When a block contains a liquid, controls the directions in which the liquid can't flow out from the block. Also controls the directions in which a block can stop liquid flowing into it if `no_reaction` is set for the `on_liquid_touches` field. Can be a list of the following directions: "up", "down", "north", "south", "east", "west". The default is an empty list; this means that liquid can flow out of all directions by default. |  | 
+| use_liquid_clipping | false | Boolean true/false | Whether this block uses the encompassing collider to visually clip the liquid. The encompassing collider is the smallest single AABB that contains all of the block's colliders. |  | 
 
 ## Samples
 


### PR DESCRIPTION
All properties should be for `detection_rules` with the only property for `minecraft:liquid_detection` being `detection_rules`. Below is the resulting JSON when referencing the doc before and after the changes.

Before:

```json
"minecraft:liquid_detection": {
  "detection_rules": [
    {
      "liquid_type": "water",
      "on_liquid_touches": "popped"
    }
  ],
  "can_contain_liquid": true,
  "liquid_type": "water",
  "on_liquid_touches": "popped",
  "stops_liquid_flowing_from_direction": ["north"],
  "use_liquid_clipping": true
}
```

After:

```json
"minecraft:liquid_detection": {
  "detection_rules": [
    {
      "liquid_type": "water",
      "on_liquid_touches": "popped",
      "can_contain_liquid": true,
      "stops_liquid_flowing_from_direction": ["north"],
      "use_liquid_clipping": true,
    }
  ]
}
```
