### PR TITLE
Clarify memory tier alignment table: tier 11 includes 4 GB devices; Switch 2 reports as Tier 1

### DIFF
--- a/creator/Documents/BuildingSubpacks.md
+++ b/creator/Documents/BuildingSubpacks.md
@@ -112,11 +112,14 @@ With our new tier system, each tier represents a different platform. So, there's
 
 | Memory Performance Tier | Platform | Memory Tier | Memory Range (GB) |
 |:--|:--|:--|:--|
-|1|Nintendo Switch |&le;11|2-4|
-|2|PS4; PS4 Pro; Xbox One; Xbox One S; 60% Mobile |12-16|4-5|
+|1|Nintendo Switch; Nintendo Switch 2 |&le;11|2-4 (4 GB included)|
+|2|PS4; PS4 Pro; Xbox One; Xbox One S; 60% Mobile |12-16|>4-5|
 |3|Xbox One X; Xbox Series S |18-20|6-8|
 |4|Xbox Series X; PS5 |24-28|8-12|
 |5|PS5 Pro; 70% PC|&ge;32|>12|
+
+> [!Note]
+> Memory tier 11 covers devices with up to and including 4 GB of RAM; memory tier 12 begins strictly above 4 GB. Devices with exactly 4 GB of RAM (a large share of mobile devices) report memory tier &le;11 and cannot select a sub-pack that requires `memory_tier` 12 or higher. Also note that the Nintendo Switch 2 is treated as a Tier 1 device like the original Nintendo Switch, even though it has 12 GB of RAM.
 
 By default, the system scans the list of subpacks in your manifest file for the highest `memory_performance_tier` value that doesn't exceed the tier of the player's device to select a sub-pack. Players can change the subpack selection to one lower than the default as long as it's within their platform capabilities. For example, a PS5 Pro defaults to Tier 5 but can be manually changed to select Tier 4 instead.
 

--- a/creator/Documents/BuildingSubpacks.md
+++ b/creator/Documents/BuildingSubpacks.md
@@ -112,14 +112,15 @@ With our new tier system, each tier represents a different platform. So, there's
 
 | Memory Performance Tier | Platform | Memory Tier | Memory Range (GB) |
 |:--|:--|:--|:--|
-|1|Nintendo Switch; Nintendo Switch 2 |&le;11|2-4 (4 GB included)|
+|0|Low-end mobile devices (for example, iPhone 7; Samsung Galaxy Tab A6) |&le;7|<3|
+|1|Nintendo Switch; Nintendo Switch 2; most 3&ndash;4 GB mobile devices |8-11|3-4 (4 GB included)|
 |2|PS4; PS4 Pro; Xbox One; Xbox One S; 60% Mobile |12-16|>4-5|
 |3|Xbox One X; Xbox Series S |18-20|6-8|
 |4|Xbox Series X; PS5 |24-28|8-12|
 |5|PS5 Pro; 70% PC|&ge;32|>12|
 
 > [!Note]
-> Memory tier 11 covers devices with up to and including 4 GB of RAM; memory tier 12 begins strictly above 4 GB. Devices with exactly 4 GB of RAM (a large share of mobile devices) report memory tier &le;11 and cannot select a sub-pack that requires `memory_tier` 12 or higher. Also note that the Nintendo Switch 2 is treated as a Tier 1 device like the original Nintendo Switch, even though it has 12 GB of RAM.
+> Memory tier 11 covers devices with up to and including 4 GB of RAM; memory tier 12 begins strictly above 4 GB. Devices with exactly 4 GB of RAM (a large share of mobile devices) report memory tier &le;11 and cannot select a sub-pack that requires `memory_tier` 12 or higher. As reference points, memory tier 8 corresponds to roughly 3 GB and memory tier 7 to roughly 2.5 GB. Also note that the Nintendo Switch 2 is currently treated as a Tier 1 device like the original Nintendo Switch, even though it has 12 GB of RAM, because it runs the original Nintendo Switch version of the game until the native Nintendo Switch 2 edition releases.
 
 By default, the system scans the list of subpacks in your manifest file for the highest `memory_performance_tier` value that doesn't exceed the tier of the player's device to select a sub-pack. Players can change the subpack selection to one lower than the default as long as it's within their platform capabilities. For example, a PS5 Pro defaults to Tier 5 but can be manually changed to select Tier 4 instead.
 


### PR DESCRIPTION
## Summary

The **Memory tier alignment** table in `BuildingSubpacks.md` is ambiguous at the tier 1 / tier 2 boundary: it lists tier 1 as `2-4 GB` and tier 2 as `4-5 GB`, so a creator cannot tell which side a 4 GB device lands on. In practice, memory tier 11 covers devices **up to and including 4 GB** of RAM, and memory tier 12 starts **strictly above 4 GB**.

This matters a lot for real content: 4 GB is one of the most common mobile RAM sizes (iPhone 13/13 mini, iPad 9th/10th gen, many Samsung A-series, etc.). We (PokeBedrock, a large Bedrock server) shipped a resource pack with a `memory_tier: 12` sub-pack based on this table, expecting 4 GB devices to qualify, and a large portion of our mobile player base was unable to select that sub-pack at all. Device testing across dozens of player-reported devices confirmed the 4-GB-inclusive boundary on tier 11.

## Updated table

| Memory Performance Tier | Platform | Memory Tier | Memory Range (GB) |
|:--|:--|:--|:--|
|0|Low-end mobile devices (for example, iPhone 7; Samsung Galaxy Tab A6) |&le;7|<3|
|1|Nintendo Switch; Nintendo Switch 2; most 3&ndash;4 GB mobile devices |8-11|3-4 (4 GB included)|
|2|PS4; PS4 Pro; Xbox One; Xbox One S; 60% Mobile |12-16|>4-5|
|3|Xbox One X; Xbox Series S |18-20|6-8|
|4|Xbox Series X; PS5 |24-28|8-12|
|5|PS5 Pro; 70% PC|&ge;32|>12|

## Changes

- Add a new tier `0` row for low-end mobile devices below the Nintendo Switch class (under ~3 GB of RAM, memory tier &le;7). The Script API's `MemoryTier` enum similarly starts at `SuperLow = 0`, so the 1-5 table left the lowest class of devices unrepresented.
- Mark the tier 1 memory range as `3-4 (4 GB included)` and the tier 2 range as `>4-5` to make the 4 GB boundary explicit.
- Add Nintendo Switch 2 to the tier 1 platform list, with an explanation: it currently runs the original Switch version of the game (the [native Switch 2 edition](https://www.minecraft.net/en-us/article/minecraft-coming-nintendo-switch-2) is announced but not yet released), so it is flagged as a Switch 1 and tiered accordingly despite having 12 GB of RAM.
- Add a note spelling out the boundary and reference points from testing: memory tier 7 &asymp; 2.5 GB, memory tier 8 &asymp; 3 GB, memory tier 11 = up to 4 GB inclusive, memory tier 12 = strictly above 4 GB.

## Empirical data points

From direct testing with a two-sub-pack manifest (a 2D fallback at `memory_tier: 1` and a full-3D sub-pack whose `memory_tier` we varied):

- HP laptop with 3 GB RAM: could not select the 3D sub-pack at `memory_tier: 9`, could at `memory_tier: 8` — tier 8 &asymp; 3 GB.
- Realme Narzo 50A (4 GB): could not select at `memory_tier: 12`, could at 11 — 4 GB is included in tier 11, tier 12 is >4 GB.
- Nintendo Switch 2 (12 GB): could not select at `memory_tier: 12`; `memory_tier: 11` allowed it to load the 3D models — it reports as an original Switch (Tier 1) device.

## Confirmed affected devices

Devices reported by players who could not select a `memory_tier: 12` sub-pack, with RAM per model spec (ranges where the model shipped in multiple configurations):

| Device | RAM (GB) |
|:--|:--|
| iPhone 7 | 2 |
| Samsung Galaxy Tab A6 | 1.5-3 |
| iPad 9th generation | 3 |
| iPhone SE 2nd generation | 3 |
| Infinix Smart 9 | 3-4 |
| Samsung Galaxy A03s | 3-4 |
| Oppo A16 | 3-4 |
| Realme C15 | 4 |
| Realme Narzo 50A | 4 |
| Galaxy Tab S6 Lite (SM-P610) | 4 |
| iPad 10th generation | 4 |
| iPhone 13 | 4 |
| iPhone 13 mini | 4 |
| iPhone 11 Pro Max | 4 |
| Tecno Spark Go 1 | 4 |
| Tecno Spark 30c | 4-8 |
| Moto G 2026 | 4 |
| Motorola 2024 | 4 |
| OPPO A53 | 4-6 |
| Samsung Galaxy A7 | 4-6 |
| Samsung Galaxy A16 5G | 4-8 |
| Samsung Galaxy A15 | 4-8 |
| Samsung Galaxy A17 | 4-8 |
| Samsung Galaxy A52 | 4-8 |
| iPad 11th generation | 6 |
| Samsung Galaxy A12 | 6 |
| iPhone 15 | 6 |
| Huawei P30 | 6-8 |
| iPhone 15 Pro Max | 8 |
| Honor X7c | 8 |
| Nintendo Switch 2 | 12 |

Note the 6-8 GB devices in this list: several of them still could not select the `memory_tier: 12` sub-pack, which shows the reported memory tier is based on the memory budget the OS makes available to the game rather than the device's physical RAM — another reason the GB ranges in this table need explicit boundaries.
